### PR TITLE
overtimes tableのカラムの変更

### DIFF
--- a/app/models/overtime.rb
+++ b/app/models/overtime.rb
@@ -1,3 +1,10 @@
 class Overtime < ApplicationRecord
   belongs_to :user
+  attr_accessor :work_time
+  before_validation :convert_work_time_to_work_time_minutes
+
+  private
+    def convert_work_time_to_work_time_minutes
+      self.work_time_minutes = (Tod::TimeOfDay.parse(self.work_time).to_i / 60)
+    end
 end

--- a/db/migrate/20200404011956_remove_work_time_from_overtimes.rb
+++ b/db/migrate/20200404011956_remove_work_time_from_overtimes.rb
@@ -1,0 +1,5 @@
+class RemoveWorkTimeFromOvertimes < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :overtimes, :work_time, :time
+  end
+end

--- a/db/migrate/20200404011956_remove_work_time_from_overtimes.rb
+++ b/db/migrate/20200404011956_remove_work_time_from_overtimes.rb
@@ -1,5 +1,9 @@
 class RemoveWorkTimeFromOvertimes < ActiveRecord::Migration[5.2]
-  def change
-    remove_column :overtimes, :work_time, :time
+  def up
+    remove_column :overtimes, :work_time, :time, null: false
+  end
+
+  def down
+    add_column :overtimes, :work_time, :time, null: false
   end
 end

--- a/db/migrate/20200404013159_add_work_time_minutes_to_overtimes.rb
+++ b/db/migrate/20200404013159_add_work_time_minutes_to_overtimes.rb
@@ -1,5 +1,9 @@
 class AddWorkTimeMinutesToOvertimes < ActiveRecord::Migration[5.2]
-  def change
-    add_column :overtimes, :work_time_minutes, :integer
+  def up
+    add_column :overtimes, :work_time_minutes, :integer, null: false
+  end
+
+  def down
+    remove_column :overtimes, :work_time_minutes, :integer, null: false
   end
 end

--- a/db/migrate/20200404013159_add_work_time_minutes_to_overtimes.rb
+++ b/db/migrate/20200404013159_add_work_time_minutes_to_overtimes.rb
@@ -1,0 +1,5 @@
+class AddWorkTimeMinutesToOvertimes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :overtimes, :work_time_minutes, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_25_133938) do
+ActiveRecord::Schema.define(version: 2020_04_04_011956) do
 
   create_table "overtimes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.date "date", null: false
     t.time "work_start_time", null: false
     t.time "work_end_time", null: false
-    t.time "work_time", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_04_011956) do
+ActiveRecord::Schema.define(version: 2020_04_04_013159) do
 
   create_table "overtimes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.date "date", null: false
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define(version: 2020_04_04_011956) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "work_time_minutes", null: false
     t.index ["user_id", "date"], name: "index_overtimes_on_user_id_and_date", unique: true
     t.index ["user_id"], name: "index_overtimes_on_user_id"
   end


### PR DESCRIPTION
### 作業内容
- overtimes tableのカラム
  - work_time :timeを削除
  - work_time_minutes :integerを追加
- overtime modelに仮想属性であるwork_timeを定義
### 作業の経緯
今後月毎の残業合計時間をグラフにする際、work_timeを `{"2019年04月"=>○○:○○, "2019年05月"=>○○:○○, …} ` という形で整理したいと考えていました。
しかし、time型では時間の集計が困難であったため、 集計が容易になるよう、integer型に変更する事としました。
