### PR TITLE
個人の月毎の残業時間を表すグラフを実装

### DIFF
--- a/app/assets/javascripts/overtimes.js
+++ b/app/assets/javascripts/overtimes.js
@@ -1,5 +1,6 @@
 document.addEventListener('turbolinks:load', () => {
 
+  // 入力フォーム
   // viewのformでtime_selectを使用した箇所には、自動的にidが付与される
   const workStartTimeHour = document.getElementById("overtime_work_start_time_4i")
   const workStartTimeMinute = document.getElementById("overtime_work_start_time_5i")
@@ -21,5 +22,33 @@ document.addEventListener('turbolinks:load', () => {
       workTime.value = workTimeValue
     });
   });
+
+
+  // 個人毎のグラフ
+  // グラフを描く場所を取得
+  const chartContext = document.getElementById("chart").getContext('2d')
+
+  // 年月・残業時間のデータ
+  let months = Object.keys(gon.monthly_chart_data)
+  let overtimes = Object.values(gon.monthly_chart_data)
+
+  let overtimeData = {
+    labels: months,
+    datasets: [{
+        label: '(時間)',
+        data: overtimes,
+        backgroundColor: 'rgba(255, 99, 132, 0.2)',
+        borderColor: 'rgba(255, 99, 132, 1)',
+        borderWidth: 1
+    }]
+  }
+
+  // グラフを描画
+  new Chart(chartContext, {
+    type: 'bar',
+    data: overtimeData,
+
+  })
+
 
 })

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,7 @@
 class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
+
+    gon.monthly_chart_data = Overtime.monthly_chart_data(params[:id])
   end
 end

--- a/app/models/overtime.rb
+++ b/app/models/overtime.rb
@@ -22,6 +22,7 @@ class Overtime < ApplicationRecord
   # end
 
   private
+
     def convert_work_time_to_work_time_minute
       self.work_time_minute = Tod::TimeOfDay.parse(self.work_time).to_i / 60
     end

--- a/app/models/overtime.rb
+++ b/app/models/overtime.rb
@@ -8,7 +8,7 @@ class Overtime < ApplicationRecord
     year_and_month_minute_data = Overtime.where(user_id: userid).group("extract(year from date)").group("extract(month from date)").sum(:work_time_minute)
     monthly_hour_data = {}
     year_and_month_minute_data.each do |key, value|
-      monthly_hour_data["#{key[0]}年#{key[1]}月"] = value / 60
+      monthly_hour_data["#{key[0].floor}年#{key[1].floor}月"] = value / 60
     end
     monthly_hour_data
   end

--- a/app/models/overtime.rb
+++ b/app/models/overtime.rb
@@ -1,10 +1,28 @@
 class Overtime < ApplicationRecord
   belongs_to :user
   attr_accessor :work_time
-  before_validation :convert_work_time_to_work_time_minutes
+  before_validation :convert_work_time_to_work_time_minute
+
+  def self.monthly_chart_data(userid)
+    monthly_minute_data = Overtime.where(user_id: userid).group("DATE_FORMAT(date,'%Y年%m月')").sum(:work_time_minute)
+    monthly_hour_data = {}
+    monthly_minute_data.each do |key, value|
+      monthly_hour_data[key] = value / 60
+    end
+    monthly_hour_data
+  end
+
+  # def self.monthly_chart_data(user)
+  #   monthly_minute_data = user.overtimes.group("DATE_FORMAT(date,'%Y年%m月')").sum(:work_time_minute)
+  #   monthly_hour_data = {}
+  #   monthly_minute_data.each do |key, value|
+  #     monthly_hour_data[key] = value / 60
+  #   end
+  #   monthly_hour_data
+  # end
 
   private
-    def convert_work_time_to_work_time_minutes
-      self.work_time_minutes = (Tod::TimeOfDay.parse(self.work_time).to_i / 60)
+    def convert_work_time_to_work_time_minute
+      self.work_time_minute = Tod::TimeOfDay.parse(self.work_time).to_i / 60
     end
 end

--- a/app/models/overtime.rb
+++ b/app/models/overtime.rb
@@ -4,22 +4,14 @@ class Overtime < ApplicationRecord
   before_validation :convert_work_time_to_work_time_minute
 
   def self.monthly_chart_data(userid)
-    monthly_minute_data = Overtime.where(user_id: userid).group("DATE_FORMAT(date,'%Y年%m月')").sum(:work_time_minute)
+    # {[2019, 4]=>○○○○, [2019, 5]=>○○○○, …} を生成
+    year_and_month_minute_data = Overtime.where(user_id: userid).group("extract(year from date)").group("extract(month from date)").sum(:work_time_minute)
     monthly_hour_data = {}
-    monthly_minute_data.each do |key, value|
-      monthly_hour_data[key] = value / 60
+    year_and_month_minute_data.each do |key, value|
+      monthly_hour_data["#{key[0]}年#{key[1]}月"] = value / 60
     end
     monthly_hour_data
   end
-
-  # def self.monthly_chart_data(user)
-  #   monthly_minute_data = user.overtimes.group("DATE_FORMAT(date,'%Y年%m月')").sum(:work_time_minute)
-  #   monthly_hour_data = {}
-  #   monthly_minute_data.each do |key, value|
-  #     monthly_hour_data[key] = value / 60
-  #   end
-  #   monthly_hour_data
-  # end
 
   private
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= include_gon %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -32,4 +32,9 @@
     <%= form.submit '新規登録', class: 'btn btn-primary btn-block' %>
   </div>
 
+
+
+
+  <canvas id="chart"></canvas>
+
 <% end %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/db/migrate/20200404122841_rename_work_time_minutes_column_to_overtimes.rb
+++ b/db/migrate/20200404122841_rename_work_time_minutes_column_to_overtimes.rb
@@ -1,4 +1,5 @@
 class RenameWorkTimeMinutesColumnToOvertimes < ActiveRecord::Migration[5.2]
   def change
+    rename_column :overtimes, :work_time_minutes, :work_time_minute
   end
 end

--- a/db/migrate/20200404122841_rename_work_time_minutes_column_to_overtimes.rb
+++ b/db/migrate/20200404122841_rename_work_time_minutes_column_to_overtimes.rb
@@ -1,0 +1,4 @@
+class RenameWorkTimeMinutesColumnToOvertimes < ActiveRecord::Migration[5.2]
+  def change
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_04_013159) do
+ActiveRecord::Schema.define(version: 2020_04_04_122841) do
 
   create_table "overtimes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.date "date", null: false
@@ -19,7 +19,7 @@ ActiveRecord::Schema.define(version: 2020_04_04_013159) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "work_time_minutes", null: false
+    t.integer "work_time_minute", null: false
     t.index ["user_id", "date"], name: "index_overtimes_on_user_id_and_date", unique: true
     t.index ["user_id"], name: "index_overtimes_on_user_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,9 +13,9 @@ END_DATE = Date.today
 WORK_START_TIME = Tod::TimeOfDay.parse("17:15")
 # => #<Tod::TimeOfDay:0x00007f8bc84accb0 @hour=17, @minute=15, @second=0, @second_of_day=62100>
 MIN_WORK_END_TIME = Tod::TimeOfDay.parse("17:16")
-MIN_WORK_END_TIME_SCOND = MIN_WORK_END_TIME.second_of_day
+MIN_WORK_END_TIME_MINUTE = MIN_WORK_END_TIME.second_of_day / 60
 MAX_WORK_END_TIME = Tod::TimeOfDay.parse("24:00")
-MAX_WORK_END_TIME_SECOND = MAX_WORK_END_TIME.second_of_day
+MAX_WORK_END_TIME_MINUTE = MAX_WORK_END_TIME.second_of_day / 60
 
 # 入力確率 1/(RECORD_CONSTANT) の確率でデータを記録
 RECORD_CONSTANT = 3
@@ -32,14 +32,13 @@ user.overtimes.destroy_all
 overtimes = []
 (START_DATE..END_DATE).each do |date|
   next unless rand(RECORD_CONSTANT).zero?
-
-  WORK_END_TIME = Tod::TimeOfDay.new(0) + rand(MIN_WORK_END_TIME_SCOND..MAX_WORK_END_TIME_SECOND)
+  WORK_END_TIME = Tod::TimeOfDay.new(0) + rand(MIN_WORK_END_TIME_MINUTE..MAX_WORK_END_TIME_MINUTE) * 60
   overtimes << {
     user_id: user.id,
     date: date,
     work_start_time: WORK_START_TIME.to_s,
     work_end_time: WORK_END_TIME.to_s,
-    work_time: (WORK_END_TIME - WORK_START_TIME).to_s,
+    work_time: (WORK_END_TIME - WORK_START_TIME).to_s
   }
 end
 Overtime.create!(overtimes)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,13 +32,14 @@ user.overtimes.destroy_all
 overtimes = []
 (START_DATE..END_DATE).each do |date|
   next unless rand(RECORD_CONSTANT).zero?
+
   WORK_END_TIME = Tod::TimeOfDay.new(0) + rand(MIN_WORK_END_TIME_MINUTE..MAX_WORK_END_TIME_MINUTE) * 60
   overtimes << {
     user_id: user.id,
     date: date,
     work_start_time: WORK_START_TIME.to_s,
     work_end_time: WORK_END_TIME.to_s,
-    work_time: (WORK_END_TIME - WORK_START_TIME).to_s
+    work_time: (WORK_END_TIME - WORK_START_TIME).to_s,
   }
 end
 Overtime.create!(overtimes)


### PR DESCRIPTION
### 作業内容
- 個人の月毎の残業時間を表すグラフを実装
- seedで投入される残業終了時間の秒数が0になるよう修正

### 今後の要対応事項
ある月の残業時間が0の場合、横軸の時系列が不連続となる。

### その他
herokuへのpush後
- クラスメソッドで使用していた `date_format()` が、PostgreSQLでは使用不可とのエラー
　→MySQLとPostgreSQLの両方で使える `extract()` の使用に変更し、
　　フォーマットは別個に整えるよう修正。
- グラフの横軸の年、月が、小数第一位（XX.0 というように）まで表示される
　→小数点以下切り捨てに修正