### PR TITLE
MySQL in heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 git_source(:github) {|repo| "https://github.com/#{repo}.git" }
 
 ruby "2.6.2"
+gem "mysql2", ">= 0.4.4", "< 0.6.0"
 gem "bootsnap", ">= 1.1.0", require: false
 gem "puma", "~> 3.11"
 gem "rails", "~> 5.2.3"
@@ -29,7 +30,6 @@ gem "tod"
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
   gem "factory_bot_rails"
-  gem "mysql2", ">= 0.4.4", "< 0.6.0"
   gem "pry-byebug"
   gem "pry-doc"
   gem "pry-rails"
@@ -48,7 +48,6 @@ group :development do
 end
 
 group :production do
-  gem "pg"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source "https://rubygems.org"
 git_source(:github) {|repo| "https://github.com/#{repo}.git" }
 
 ruby "2.6.2"
-gem "mysql2", ">= 0.4.4", "< 0.6.0"
 gem "bootsnap", ">= 1.1.0", require: false
+gem "mysql2", ">= 0.4.4", "< 0.6.0"
 gem "puma", "~> 3.11"
 gem "rails", "~> 5.2.3"
 gem "sass-rails", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,6 @@ GEM
     parallel (1.19.1)
     parser (2.7.0.5)
       ast (~> 2.4.0)
-    pg (1.2.3)
     popper_js (1.16.0)
     pry (0.13.0)
       coderay (~> 1.1)
@@ -286,7 +285,6 @@ DEPENDENCIES
   jquery-rails
   listen (>= 3.0.5, < 3.2)
   mysql2 (>= 0.4.4, < 0.6.0)
-  pg
   pry-byebug
   pry-doc
   pry-rails


### PR DESCRIPTION
本番環境で使用するデータベースを、herokuのデフォルトであるPostgreSQLから、MySQLに変更。