### PR TITLE
Index chart

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,8 @@
 class UsersController < ApplicationController
   def index
     @users = User.all.order(:group)
+
+    gon.group_monthly_chart_data = Overtime.group_monthly_chart_data
   end
 
   def show

--- a/app/models/overtime.rb
+++ b/app/models/overtime.rb
@@ -14,12 +14,35 @@ class Overtime < ApplicationRecord
   def self.monthly_chart_data(userid)
     # {[2019, 4]=>○○○○, [2019, 5]=>○○○○, …} を生成
     year_and_month_minute_data = Overtime.where(user_id: userid).group("extract(year from date)").group("extract(month from date)").sum(:work_time_minute)
+    # {["2019年4月"=>○○○○, "2019年4月"=>○○○○, …} に成形
     monthly_hour_data = {}
     year_and_month_minute_data.each do |key, value|
       monthly_hour_data["#{key[0].floor}年#{key[1].floor}月"] = (value.to_f / 60).floor(1)
     end
     monthly_hour_data
   end
+
+
+  # index-chart用
+  def self.group_monthly_hour_data
+    # {["A", "2019年4月"]=>1828, ["A", "2019年5月"]=>6418, ...} を生成
+    group_monthly_minute_data = Overtime.joins(:user).select("overtimes*, users*").group("users.group").group("DATE_FORMAT(date,'%Y年%c月')").sum(:work_time_minute)
+    hash = {}
+    group_monthly_minute_data.each do |key, value|
+      hash[key] = (value.to_f / 60).floor(1)
+    end
+    hash
+  end
+
+  def self.group_monthly_chart_data
+    # {"A"=> {"2019年4月"=>30.4, "2019年5月"=>106.9, ...} に成形
+    hash = Hash.new { |h,k| h[k] = {} }
+    Overtime.group_monthly_hour_data.each do |key, value|
+      hash[key[0]][key[1]] = value
+    end
+    hash
+  end
+
 
   private
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,3 +1,6 @@
+<canvas id="index-chart" class="mb-5"></canvas>
+
+
 <p>今月の残業時間</p>
 
 <table class="table table-hover" id="index-table">

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,7 +22,7 @@ puts "テストユーザーの初期データを投入しました"
 
 # overtime
 # データの入力期間
-YEARS = 3
+YEARS = 2
 START_DATE = Date.today - (YEARS * 12).months
 END_DATE = Date.today
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,24 +1,29 @@
 # user
-GROUPS = ["A", "B", "C"].freeze
+GROUPS = ["A", "B", "C", "D", "E", "F", "G"].freeze
 PASSWORD = "password".freeze
+NUMBER_OF_USERS_PER_GROUP = 3
+
+number_of_groups = GROUPS.length
+number_of_users = NUMBER_OF_USERS_PER_GROUP * number_of_groups
 
 users = []
-3.times {
-  GROUPS.each do |group|
-    users << {
-      name: Gimei.unique.name.kanji,
-      group: group,
-      email: Faker::Internet.email,
-      password: PASSWORD,
-    }
-  end
-}
+for i in (1..number_of_users) do
+  group_index = i % number_of_groups - 1
+  users << {
+    name: Gimei.unique.name.kanji,
+    group: GROUPS[group_index],
+    email: "user_id_#{i}@email.com",
+    password: PASSWORD,
+  }
+end
+
 User.create!(users)
 puts "テストユーザーの初期データを投入しました"
 
 # overtime
 # データの入力期間
-START_DATE = Date.today - 12.months
+YEARS = 3
+START_DATE = Date.today - (YEARS * 12).months
 END_DATE = Date.today
 
 # 記録する時刻の範囲


### PR DESCRIPTION
### 作業内容
indexのviewにグループ毎の残業時間推移を示すグラフを設置
- overtimeモデルにおいて、dbから取り出したデータを整形
- jsでグラフ 描画に使用するデータを整形、グラフを描画
- seedのuser数、及び期間を変更

### その他
jsでは、showとindexのグラフ描画において全く同じコードが存在しDRYでない。要改善。